### PR TITLE
Use newer Buffer syntax

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -64,7 +64,7 @@ const makeRequest = function postRequest(hostName, endpoint, methodName, data, t
 
 
 const base64Encode = (encodeData) => {
-    const buff = new Buffer(encodeData);
+    const buff = Buffer.from(encodeData);
     return buff.toString('base64');
 };
 


### PR DESCRIPTION
## Goal of the pull request:
* [ ] Documentation
* [x] Bugfix
* [ ] Feature (New!)
* [ ] Enhancement


## Description
@pajaydev I believe this should fix the deprecation warning I was receiving:

```bash
(node:99835) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```

https://stackoverflow.com/questions/52165333/deprecationwarning-buffer-is-deprecated-due-to-security-and-usability-issues

