### PR TITLE
fix for findItemsByKeywords (#76)

### DIFF
--- a/src/findingApi.js
+++ b/src/findingApi.js
@@ -15,8 +15,12 @@ const findItemsByKeywords = function (options) {
     this.options.param = 'keywords';
     // support only keyword string.
     if (!options.keywords) {
-        this.options.name = options;
+        this.options.name = encodeURIComponent(options);
     }
+    else {
+        options.keywords = encodeURIComponent(options.keywords);
+    }
+
     this.options.additionalParam = constructAdditionalParams(options);
     const url = urlObject.buildSearchUrl(this.options);
     return getRequest(url).then((data) => {

--- a/src/findingApi.js
+++ b/src/findingApi.js
@@ -14,13 +14,8 @@ const findItemsByKeywords = function (options) {
     this.options.operationName = FIND_ITEMS_BY_KEYWORD;
     this.options.param = 'keywords';
     // support only keyword string.
-    if (!options.keywords) {
-        this.options.name = encodeURIComponent(options);
-    }
-    else {
-        options.keywords = encodeURIComponent(options.keywords);
-    }
-
+    if (!options.keywords) options = { keywords: options };
+    options.keywords = encodeURIComponent(options.keywords);
     this.options.additionalParam = constructAdditionalParams(options);
     const url = urlObject.buildSearchUrl(this.options);
     return getRequest(url).then((data) => {


### PR DESCRIPTION
Hi. Just making a simple fix for #76 (findItemsByKeywords not working when keywords have spaces and passed in in an object). FYI, this is my first ever pull request on GitHub so hope this is the correct way. Thanks.