### PR TITLE
Enabled dark and light mode with switch for docs using docsify-darklight-theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,12 @@
   <meta name="description" content="Ebay node api client">
   <meta name="viewport"
     content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-  <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+    <link 
+      rel="stylesheet"
+      href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@3/dist/style.min.css"
+      title="docsify-darklight-theme"
+      type="text/css"
+    />
 </head>
 
 <body>
@@ -23,6 +28,10 @@
         noData: 'No Results.'
       }
     }
+  </script>
+  <script 
+    src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@3/dist/index.min.js"
+    type="text/javascript">
   </script>
   <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
   <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>


### PR DESCRIPTION

## Goal of the pull request:
* [x] Documentation
* [ ] Bugfix
* [x] Feature (New!)
* [ ] Enhancement


## Description

###Before

![image](https://user-images.githubusercontent.com/10001746/83329615-1e03ea80-a2a8-11ea-8a53-dd914a2f76fe.png)

### After

#### Light Mode

![image](https://user-images.githubusercontent.com/10001746/83329633-37a53200-a2a8-11ea-890a-6d98ec3ef713.png)

#### Dask Mode

![image](https://user-images.githubusercontent.com/10001746/83329642-41c73080-a2a8-11ea-937e-b0cc19a211e8.png)


