### PR TITLE
Add buyerPostalCode option support.

### DIFF
--- a/src/common-utils/index.js
+++ b/src/common-utils/index.js
@@ -28,7 +28,7 @@ function constructAdditionalParams(options){
         if (['entriesPerPage', 'pageNumber'].includes(key)) {
             params += `paginationInput.${key}=${value}&`;
         }
-        else if (['keywords', 'categoryId', 'productId', 'sortOrder', 'storeName'].includes(key)) {
+        else if (['keywords', 'categoryId', 'productId', 'sortOrder', 'storeName', 'buyerPostalCode'].includes(key)) {
             const encodeParam = encodeURIComponent(value);
             params += `${key}=${encodeParam}&`;
         }


### PR DESCRIPTION
Add `buyerPostalCode` option support.

## Goal of the pull request:
* [ ] Documentation
* [ ] Bugfix
* [ ] Feature (New!)
* [x] Enhancement


## Description

Add buyerPostalCode to the list of options that are a key and value query string pair.
eBay docs reference: https://developer.ebay.com/devzone/finding/callref/findItemsByKeywords.html
