### PR TITLE
search by ePID with Auth flow

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,9 @@
 ## Goal of the pull request:
 * [ ] Documentation
-* [x] Bugfix
+* [ ] Bugfix
 * [ ] Feature (New!)
-* [x] Enhancement
+* [ ] Enhancement
 
 
 ## Description
 <!--- What are the changes? -->
-
-added the ability so search by epid in function 'searchItems'. It was stated in the repo's docs but there was no real way to do it using the auth flow. 
-
-marked both bugfix and enhancement because it's not a proper bug, but it's not an enhancement either since it was stated in the docs that 'searchItems' could search by ePID.
-
-Details:
-just two lines in 'src/buy-api.js'
-
-+ 52 
-
-if (!searchConfig.keyword && !searchConfig.categoryId && !searchConfig.gtin && !searchConfig.epid) throw new Error('Error --> Keyword or category id is required in query param');
-
-+ 61
-
-queryParam = queryParam + (searchConfig.epid ? '&epid=' + searchConfig.epid : '');
-

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,25 @@
 ## Goal of the pull request:
 * [ ] Documentation
-* [ ] Bugfix
+* [x] Bugfix
 * [ ] Feature (New!)
-* [ ] Enhancement
+* [x] Enhancement
 
 
 ## Description
 <!--- What are the changes? -->
+
+added the ability so search by epid in function 'searchItems'. It was stated in the repo's docs but there was no real way to do it using the auth flow. 
+
+marked both bugfix and enhancement because it's not a proper bug, but it's not an enhancement either since it was stated in the docs that 'searchItems' could search by ePID.
+
+Details:
+just two lines in 'src/buy-api.js'
+
++ 52 
+
+if (!searchConfig.keyword && !searchConfig.categoryId && !searchConfig.gtin && !searchConfig.epid) throw new Error('Error --> Keyword or category id is required in query param');
+
++ 61
+
+queryParam = queryParam + (searchConfig.epid ? '&epid=' + searchConfig.epid : '');
+

--- a/src/buy-api.js
+++ b/src/buy-api.js
@@ -49,7 +49,7 @@ const getItemByItemGroup = function (itemGroupId) {
 
 const searchItems = function (searchConfig) {
     if (!searchConfig) throw new Error('Error --> Missing or invalid input parameter to search');
-    if (!searchConfig.keyword && !searchConfig.categoryId && !searchConfig.gtin && !searchConfig.epid) throw new Error('Error --> Keyword or category id is required in query param');
+    if (!searchConfig.keyword && !searchConfig.categoryId && !searchConfig.gtin) throw new Error('Error --> Keyword or category id is required in query param');
     if (!this.options.appAccessToken) throw new Error('Error -->Missing Access token, Generate access token');
     const auth = 'Bearer ' + this.options.appAccessToken;
     let queryParam = searchConfig.keyword ? 'q=' + encodeURIComponent(searchConfig.keyword) : '';
@@ -58,7 +58,7 @@ const searchItems = function (searchConfig) {
     queryParam = queryParam + (searchConfig.limit ? '&limit=' + searchConfig.limit : '');
     queryParam = queryParam + (searchConfig.offset ? '&offset=' + searchConfig.offset : '');
     queryParam = queryParam + (searchConfig.sort ? '&sort=' + searchConfig.sort : '');
-    queryParam = queryParam + (searchConfig.sort ? '&epid=' + searchConfig.epid : '');
+    queryParam = queryParam + (searchConfig.epid ? '&epid=' + searchConfig.epid : '');
     if (searchConfig.fieldgroups !== undefined) queryParam = queryParam + '&fieldgroups=' + searchConfig.fieldgroups;
     if (searchConfig.filter !== undefined) queryParam = queryParam + '&filter=' + encodeURLQuery(makeString(searchConfig.filter, { quotes: 'no', braces: 'false' }));
     queryParam = queryParam + (searchConfig.aspect_filter ? '&aspect_filter=' + encodeURLQuery(makeString(searchConfig.aspect_filter, { quotes: 'no', braces: 'false' })) : '');

--- a/src/buy-api.js
+++ b/src/buy-api.js
@@ -49,7 +49,7 @@ const getItemByItemGroup = function (itemGroupId) {
 
 const searchItems = function (searchConfig) {
     if (!searchConfig) throw new Error('Error --> Missing or invalid input parameter to search');
-    if (!searchConfig.keyword && !searchConfig.categoryId && !searchConfig.gtin) throw new Error('Error --> Keyword or category id is required in query param');
+    if (!searchConfig.keyword && !searchConfig.categoryId && !searchConfig.gtin && !searchConfig.epid) throw new Error('Error --> Keyword or category id is required in query param');
     if (!this.options.appAccessToken) throw new Error('Error -->Missing Access token, Generate access token');
     const auth = 'Bearer ' + this.options.appAccessToken;
     let queryParam = searchConfig.keyword ? 'q=' + encodeURIComponent(searchConfig.keyword) : '';
@@ -58,6 +58,7 @@ const searchItems = function (searchConfig) {
     queryParam = queryParam + (searchConfig.limit ? '&limit=' + searchConfig.limit : '');
     queryParam = queryParam + (searchConfig.offset ? '&offset=' + searchConfig.offset : '');
     queryParam = queryParam + (searchConfig.sort ? '&sort=' + searchConfig.sort : '');
+    queryParam = queryParam + (searchConfig.sort ? '&epid=' + searchConfig.epid : '');
     if (searchConfig.fieldgroups !== undefined) queryParam = queryParam + '&fieldgroups=' + searchConfig.fieldgroups;
     if (searchConfig.filter !== undefined) queryParam = queryParam + '&filter=' + encodeURLQuery(makeString(searchConfig.filter, { quotes: 'no', braces: 'false' }));
     queryParam = queryParam + (searchConfig.aspect_filter ? '&aspect_filter=' + encodeURLQuery(makeString(searchConfig.aspect_filter, { quotes: 'no', braces: 'false' })) : '');

--- a/src/buy-api.js
+++ b/src/buy-api.js
@@ -49,7 +49,7 @@ const getItemByItemGroup = function (itemGroupId) {
 
 const searchItems = function (searchConfig) {
     if (!searchConfig) throw new Error('Error --> Missing or invalid input parameter to search');
-    if (!searchConfig.keyword && !searchConfig.categoryId && !searchConfig.gtin) throw new Error('Error --> Keyword or category id is required in query param');
+    if (!searchConfig.keyword && !searchConfig.categoryId && !searchConfig.gtin && !searchConfig.epid) throw new Error('Error --> Kindly provide the valid Keyword, category id, epid or gtin in query param');
     if (!this.options.appAccessToken) throw new Error('Error -->Missing Access token, Generate access token');
     const auth = 'Bearer ' + this.options.appAccessToken;
     let queryParam = searchConfig.keyword ? 'q=' + encodeURIComponent(searchConfig.keyword) : '';


### PR DESCRIPTION
## Goal of the pull request:
* [ ] Documentation
* [x] Bugfix
* [ ] Feature (New!)
* [x] Enhancement


## Description
<!--- What are the changes? -->

added the ability so search by epid in function 'searchItems'. It was stated in the repo's docs but there was no real way to do it using the auth flow. 

marked both bugfix and enhancement because it's not a proper bug, but it's not an enhancement either since it was stated in the docs that 'searchItems' could search by ePID.

Details:
just two lines in 'src/buy-api.js'

+ 52 

if (!searchConfig.keyword && !searchConfig.categoryId && !searchConfig.gtin && !searchConfig.epid) throw new Error('Error --> Keyword or category id is required in query param');

+ 61

queryParam = queryParam + (searchConfig.epid ? '&epid=' + searchConfig.epid : '');

