### PR TITLE
Group filter parameters

### DIFF
--- a/src/common-utils/index.js
+++ b/src/common-utils/index.js
@@ -16,7 +16,7 @@ const isString = (value)=>{
  * @param {Object} options
  */
 function constructAdditionalParams(options){
-    let params = '';
+    let params = '', filterParams = '';
     let count = 0;
     let currencyKey = this ? this.options.globalID : 'EBAY-US';
 
@@ -38,16 +38,16 @@ function constructAdditionalParams(options){
             }
         }
         else {
-            params += `itemFilter(${count}).name=${key}&`;
+            filterParams += `itemFilter(${count}).name=${key}&`;
             if (!Array.isArray(value)) {
-                params += `itemFilter(${count}).value=${value}&`;
+                filterParams += `itemFilter(${count}).value=${value}&`;
             } else {
                 for (let innerKey in value) {
-                    params += `itemFilter(${count}).value(${innerKey})=${value[innerKey]}&`;
+                    filterParams += `itemFilter(${count}).value(${innerKey})=${value[innerKey]}&`;
                 }
             }
             if(key === "MinPrice" || key === "MaxPrice"){
-                params += `itemFilter(${count}).paramName=Currency&
+                filterParams += `itemFilter(${count}).paramName=Currency&
                 itemFilter(${count}).paramValue=${currency[currencyKey]}&`;
             }
             
@@ -55,6 +55,7 @@ function constructAdditionalParams(options){
         }
         
     }
+    params += filterParams;
     // replace extra space
     params = params.replace(/\s/g, '');
     return params.substring(0, params.length - 1);

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -56,8 +56,8 @@ describe('test common util methods', () => {
         });
 
         it('test constructAdditionalParams with additional params', () => {
-            const expectedParam = 'keywords=iphone%206s&categoryId=111&sortOrder=PricePlusShippingLowest&itemFilter(0).name=Condition&itemFilter(0).value=3000&itemFilter(1).name=SoldItemsOnly&itemFilter(1).value=true&storeName=addidas%20store';
-            const expectedPaginationParam = 'keywords=iphone&categoryId=111&sortOrder=PricePlusShippingLowest&itemFilter(0).name=Condition&itemFilter(0).value=3000&itemFilter(1).name=SoldItemsOnly&itemFilter(1).value=true&paginationInput.entriesPerPage=2';
+            const expectedParam = 'keywords=iphone%206s&categoryId=111&sortOrder=PricePlusShippingLowest&storeName=addidas%20store&itemFilter(0).name=Condition&itemFilter(0).value=3000&itemFilter(1).name=SoldItemsOnly&itemFilter(1).value=true';
+            const expectedPaginationParam = 'keywords=iphone&categoryId=111&sortOrder=PricePlusShippingLowest&paginationInput.entriesPerPage=2&itemFilter(0).name=Condition&itemFilter(0).value=3000&itemFilter(1).name=SoldItemsOnly&itemFilter(1).value=true';
             const options = {
                 keywords: 'iphone 6s',
                 categoryId: '111',
@@ -79,7 +79,7 @@ describe('test common util methods', () => {
         });
 
         it('test constructAdditionalParams with Maxprice and Minprice params', () => {
-            const expectedParam = 'keywords=iphone%206s&categoryId=111&sortOrder=PricePlusShippingLowest&itemFilter(0).name=Condition&itemFilter(0).value=3000&itemFilter(1).name=SoldItemsOnly&itemFilter(1).value=true&storeName=addidas%20store&itemFilter(2).name=MinPrice&itemFilter(2).value=100.00&itemFilter(2).paramName=Currency&itemFilter(2).paramValue=USD&itemFilter(3).name=MaxPrice&itemFilter(3).value=200.00&itemFilter(3).paramName=Currency&itemFilter(3).paramValue=USD';
+            const expectedParam = 'keywords=iphone%206s&categoryId=111&sortOrder=PricePlusShippingLowest&storeName=addidas%20store&itemFilter(0).name=Condition&itemFilter(0).value=3000&itemFilter(1).name=SoldItemsOnly&itemFilter(1).value=true&itemFilter(2).name=MinPrice&itemFilter(2).value=100.00&itemFilter(2).paramName=Currency&itemFilter(2).paramValue=USD&itemFilter(3).name=MaxPrice&itemFilter(3).value=200.00&itemFilter(3).paramName=Currency&itemFilter(3).paramValue=USD';
             const options = {
                 keywords: 'iphone 6s',
                 categoryId: '111',
@@ -94,7 +94,7 @@ describe('test common util methods', () => {
         });
 
         it('test constructAdditionalParams with Maxprice and Minprice params with diff site', () => {
-            const expectedParam = 'keywords=iphone%206s&categoryId=111&sortOrder=PricePlusShippingLowest&itemFilter(0).name=Condition&itemFilter(0).value=3000&itemFilter(1).name=SoldItemsOnly&itemFilter(1).value=true&storeName=addidas%20store&itemFilter(2).name=MinPrice&itemFilter(2).value=100.00&itemFilter(2).paramName=Currency&itemFilter(2).paramValue=GBP&itemFilter(3).name=MaxPrice&itemFilter(3).value=200.00&itemFilter(3).paramName=Currency&itemFilter(3).paramValue=GBP';
+            const expectedParam = 'keywords=iphone%206s&categoryId=111&sortOrder=PricePlusShippingLowest&storeName=addidas%20store&itemFilter(0).name=Condition&itemFilter(0).value=3000&itemFilter(1).name=SoldItemsOnly&itemFilter(1).value=true&itemFilter(2).name=MinPrice&itemFilter(2).value=100.00&itemFilter(2).paramName=Currency&itemFilter(2).paramValue=GBP&itemFilter(3).name=MaxPrice&itemFilter(3).value=200.00&itemFilter(3).paramName=Currency&itemFilter(3).paramValue=GBP';
             const options = {
                 keywords: 'iphone 6s',
                 categoryId: '111',


### PR DESCRIPTION
This fixes an API error caused by any other parameter in between filter parameters.

Reference: https://forums.developer.ebay.com/questions/14689/error-value-is-required-for-item-filter-listing-ty.html

> Error: Value is required for item filter

> You're putting sortOrder in between two itemFilter parameters. Put the item filters together, in order. Move sortOrder to a different position.

## Goal of the pull request:
* [ ] Documentation
* [x] Bugfix
* [ ] Feature (New!)
* [ ] Enhancement


## Description

A minor change to how `constructAdditionalParams` concatenates parameters.
It keeps the filter parameters grouped in-case the filter properties of the options object is un-grouped. 