### PR TITLE
Update getSingleItem function

### DIFF
--- a/src/shopping.js
+++ b/src/shopping.js
@@ -66,11 +66,21 @@ const getMultipleItems = function (options) {
   * @param {String} itemId (required)
   */
 const getSingleItem = function (itemId) {
-    if (!itemId) throw new Error('invalid_request_error -> Item ID is null or invalid');
-    const requestUrl = `${urlObject.buildShoppingUrl(this.options, 'GetSingleItem')}&${stringifyUrl({ 'ItemID': itemId })} `;
-    return getRequest(requestUrl).then((data) => {
-        return JSON.parse(data);
-    }, console.error // eslint-disable-line no-console
+    if (!input || (typeof input !== 'object' && typeof input !== 'string'))
+        throw new Error('invalid_request_error -> Invalid input');
+    // To preserve backwards compatibility
+    if (typeof input === 'string') {
+        input = { ItemID: input };
+    }
+    const requestUrl = `${urlObject.buildShoppingUrl(
+        this.options,
+        'GetSingleItem'
+    )}&${stringifyUrl(input)} `;
+    return getRequest(requestUrl).then(
+        (data) => {
+            return JSON.parse(data);
+        },
+        console.error // eslint-disable-line no-console
     );
 };
 


### PR DESCRIPTION
Update `getSingleItem` to accept object as parameter.

## Goal of the pull request:
* [ ] Documentation
* [ ] Bugfix
* [ ] Feature (New!)
* [x] Enhancement


## Description
This change allows for additional parameters to be passed to  `getSingleItem`. For example in a similar way to `getShippingCosts`.

It can be used as before with a string of ItemID, backwards compatibility is preserved.

Also, an object may be passed, to add parameters refferenced in the [eBay GetSingleItem docs](https://developer.ebay.com/Devzone/shopping/docs/CallRef/GetSingleItem.html)

e.g. 
```
ebay.getSingleItem({
      itemId: ebayId,
      includeSelector: 'Description',
});
```